### PR TITLE
debian: modernize and improve debian build

### DIFF
--- a/pack/debian/changelog
+++ b/pack/debian/changelog
@@ -1,6 +1,12 @@
-srain (1.0.0) stable; urgency=medium
+srain (1.0.1-1) unstable; urgency=medium
 
-  * Changes: 
+  * cleaned debian stuff
+
+ -- David Heidelberg <david@ixit.cz>  Mon, 16 Mar 2020 13:25:39 +0000
+
+srain (1.0.0-1) unstable; urgency=medium
+
+  * Changes:
     - Some code cleanup
     - Update Quick Start documentation
 

--- a/pack/debian/control
+++ b/pack/debian/control
@@ -2,29 +2,34 @@ Source: srain
 Section: net
 Priority: optional
 Maintainer: Shengyu Zhang <i@silverrainz.me>
-Build-Depends: 
-  debhelper (>= 9), 
-  gettext, 
-  libconfig-dev,
-  libgtk-3-dev,
-  libsecret-1-dev,
-  libsoup2.4-dev, 
-  libssl-dev,
-  pkg-config,
-Standards-Version: 3.9.8
+Build-Depends:
+	debhelper-compat (= 12),
+	gettext,
+	libconfig-dev,
+	libgtk-3-dev,
+	libsecret-1-dev,
+	libsoup2.4-dev,
+	libssl-dev,
+	pkg-config,
+Standards-Version: 4.5.0
+Rules-Requires-Root: no
 Homepage: https://github.com/SrainApp/srain/
 Vcs-Browser: https://github.com/SrainApp/srain/
-Vcs-Git: git://github.com/SrainApp/srain.git
+Vcs-Git: https://github.com/SrainApp/srain.git
+
 
 Package: srain
 Architecture: any
-Depends: 
-  ${shlibs:Depends}, 
-  ${misc:Depends}, 
-  glib-networking, 
-  libconfig9 (>= 1.5), 
-  libgtk-3-0 (>= 3.16), 
-  libsecret-1-0, 
-  libsoup2.4-1, 
-Description: Srain IRC client
- Modern IRC client written in GTK.
+Depends:
+	${shlibs:Depends},
+	${misc:Depends},
+	glib-networking,
+	libconfig9 (>= 1.5),
+	libgtk-3-0 (>= 3.16),
+	libsecret-1-0,
+	libsoup2.4-1,
+Description: Modern IRC client
+ Modern IRC client written in GTK with partial IRCv3 support and geek features.
+ .
+ It's easy to use and offers advanced features.
+ Compatible with RFC {1459,2812} and fully open-source.

--- a/pack/debian/copyright
+++ b/pack/debian/copyright
@@ -8,7 +8,7 @@ License: GPL-3.0+
 
 Files: debian/*
 Copyright: 2016 yangfl <mmyangfl@gmail.com>
-License: MIT
+License: Expat
 
 License: GPL-3.0+
  This program is free software: you can redistribute it and/or modify
@@ -26,3 +26,25 @@ License: GPL-3.0+
  .
  On Debian systems, the complete text of the GNU General
  Public License version 3 can be found in "/usr/share/common-licenses/GPL-3".
+
+License: Expat
+ Copyright (c) 1998, 1999, 2000 Thai Open Source Software Center Ltd
+ .
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+ .
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/pack/debian/rules
+++ b/pack/debian/rules
@@ -1,5 +1,7 @@
 #!/usr/bin/make -f
 
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+
 %:
 	dh $@
 

--- a/pack/debian/upstream/metadata
+++ b/pack/debian/upstream/metadata
@@ -1,0 +1,5 @@
+Bug-Database: https://github.com/SrainApp/srain/issues
+Bug-Submit: https://github.com/SrainApp/srain/issues/new
+Repository: https://github.com/SrainApp/srain/.git
+Repository-Browse: https://github.com/SrainApp/srain/
+Security-Contact: Shengyu Zhang <i@silverrainz.me>

--- a/pack/debian/watch
+++ b/pack/debian/watch
@@ -1,4 +1,4 @@
 version=4
-opts="filenamemangle=s%(?:.*?)?v?(\d[\d.]*)\.tar\.gz%<project>-$1.tar.gz%" \
-https://github.com/SrainApp/srain/tags  (?:.*?/)?v?(\d[\d.]*)\.tar\.gz  debian  uupdate
-# Site/Directory                           Pattern                         Version Script
+opts="filenamemangle=s%(?:.*?)?v?(\d[\d.]*)\.tar\.gz%webp-pixbuf-loader-$1.tar.gz%" \
+	https://github.com/SrainApp/srain/tags \
+	(?:.*?/)?v?(\d[\d.]*)\.tar\.gz debian uupdate


### PR DESCRIPTION
Still many lintian warnings, but at least some of them are gone now.

Remaining warnings:
```
$ lintian -iIE --pedantic --show-overrides --color auto --no-tag-display-limit ../srain_1.0.1-1_amd64.changes
E: srain: possible-gpl-code-linked-with-openssl
N: 
N:    This package appears to be covered by the GNU GPL but depends on the
N:    OpenSSL libssl package and does not mention a license exemption or
N:    exception for OpenSSL in its copyright file. The GPL (including version
N:    3) is incompatible with some terms of the OpenSSL license, and therefore
N:    Debian does not allow GPL-licensed code linked with OpenSSL libraries
N:    unless there is a license exception explicitly permitting this.
N:    
N:    If only the Debian packaging, or some other part of the package not
N:    linked with OpenSSL, is covered by the GNU GPL, please add a Lintian
N:    override for this tag. Lintian currently has no good way of
N:    distinguishing between that case and problematic packages.
N:    
N:    Severity: serious, Certainty: wild-guess
N:    
N:    Check: debian/copyright, Type: source, binary
N: 
W: srain: binary-without-manpage usr/bin/srain
N: 
N:    Each binary in /usr/bin, /usr/sbin, /bin, /sbin or /usr/games should
N:    have a manual page
N:    
N:    Note that though the man program has the capability to check for several
N:    program names in the NAMES section, each of these programs should have
N:    its own manual page (a symbolic link to the appropriate manual page is
N:    sufficient) because other manual page viewers such as xman or tkman
N:    don't support this.
N:    
N:    If the name of the man page differs from the binary by case, man may be
N:    able to find it anyway; however, it is still best practice to make the
N:    case of the man page match the case of the binary.
N:    
N:    If the man pages are provided by another package on which this package
N:    depends, Lintian may not be able to determine that man pages are
N:    available. In this case, after confirming that all binaries do have man
N:    pages after this package and its dependencies are installed, please add
N:    a Lintian override.
N:    
N:    Refer to Debian Policy Manual section 12.1 (Manual pages) for details.
N:    
N:    Severity: normal, Certainty: possible
N:    
N:    Check: manpages, Type: binary
N: 
W: srain source: changelog-should-mention-nmu
N: 
N:    When you NMU a package, that fact should be mentioned on the first line
N:    in the changelog entry. Use the words "NMU" or "Non-maintainer upload"
N:    (case insensitive).
N:    
N:    Maybe you didn't intend this upload to be a NMU, in that case, please
N:    double-check that the most recent entry in the changelog is
N:    byte-for-byte identical to the maintainer or one of the uploaders. If
N:    this is a local package (not intended for Debian), you can suppress this
N:    warning by putting "local" in the version number or "local package" on
N:    the first line of the changelog entry.
N:    
N:    Refer to Debian Developer's Reference section 5.11.3 (Using the DELAYED/
N:    queue) for details.
N:    
N:    Severity: normal, Certainty: certain
N:    
N:    Check: nmu, Type: source
N: 
W: srain: command-in-menu-file-and-desktop-file srain usr/share/menu/srain:2
N: 
N:    The command is listed both in a menu file and a desktop file
N:    
N:    Per the tech-ctte decision on #741573, this is now prohibited.
N:    
N:    Please remove the menu file from the package.
N:    
N:    Refer to Debian Policy Manual section 9.6 (Menus) and
N:    https://lists.debian.org/debian-devel-announce/2015/09/msg00000.html for
N:    details.
N:    
N:    Severity: normal, Certainty: possible
N:    
N:    Check: menu-format, Type: binary
N: 
W: srain source: inconsistent-appstream-metadata-license data/srain.appdata.xml (fsfap != gpl-3.0+)
N: 
N:    The specified AppStream metadata file specifies a metadata_license field
N:    but this does not match the files in debian/copyright.
N:    
N:    Refer to https://wiki.debian.org/AppStream/Guidelines and
N:    https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/ for
N:    details.
N:    
N:    Severity: normal, Certainty: possible
N:    
N:    Check: debian/copyright, Type: source, binary
N: 
W: srain: menu-item-creates-new-section Applications/Network usr/share/menu/srain:2
N: 
N:    The menu item has a line that specifies an unknown section or uses a
N:    section that is intended only as a menu root, not as a section that
N:    applications should use directly. Check the spelling of the section and
N:    check the section against the list in the menu policy. (The menu
N:    sections changed as of June of 2007.)
N:    
N:    Refer to The Debian Menu sub-policy section 2.1 (Preferred menu
N:    structure) for details.
N:    
N:    Severity: normal, Certainty: certain
N:    
N:    Check: menu-format, Type: binary
N: 
W: srain: menu-item-needs-tag-has-unknown-value x11|text|vc|wm usr/share/menu/srain:2
N: 
N:    The menu item has a line that has a needs= field with a strange value.
N:    This may be intentional, but it's probably a typo that will make menu
N:    ignore the line.
N:    
N:    Severity: minor, Certainty: certain
N:    
N:    Check: menu-format, Type: binary
N: 
W: srain: raster-image-in-scalable-directory usr/share/icons/hicolor/scalable/apps/im.srain.Srain.png
N: 
N:    The given raster image was installed into a "scalable" icon directory.
N:    Only vector graphics (e.g. SVG) should be installed into those
N:    directories.
N:    
N:    Severity: normal, Certainty: certain
N:    
N:    Check: files, Type: binary, udeb
N: 
W: srain source: source-nmu-has-incorrect-version-number 1.0.1-1
N: 
N:    A source NMU should have a Debian revision of "-x.x" (or "+nmuX" for a
N:    native package). This is to prevent stealing version numbers from the
N:    maintainer.
N:    
N:    Maybe you didn't intend this upload to be a NMU, in that case, please
N:    double-check that the most recent entry in the changelog is
N:    byte-for-byte identical to the maintainer or one of the uploaders. If
N:    this is a local package (not intended for Debian), you can suppress this
N:    warning by putting "local" in the version number or "local package" on
N:    the first line of the changelog entry.
N:    
N:    Refer to Debian Developer's Reference section 5.11.2 (NMUs and
N:    debian/changelog) for details.
N:    
N:    Severity: normal, Certainty: certain
N:    
N:    Check: nmu, Type: source
N: 
I: srain: hardening-no-fortify-functions usr/bin/srain
N: 
N:    This package provides an ELF binary that lacks the use of fortified libc
N:    functions. Either there are no potentially unfortified functions called
N:    by any routines, all unfortified calls have already been fully validated
N:    at compile-time, or the package was not built with the default Debian
N:    compiler flags defined by dpkg-buildflags. If built using
N:    dpkg-buildflags directly, be sure to import CPPFLAGS.
N:    
N:    NB: Due to false-positives, Lintian ignores some unprotected functions
N:    (e.g. memcpy).
N:    
N:    Refer to https://wiki.debian.org/Hardening and
N:    https://bugs.debian.org/673112 for details.
N:    
N:    Severity: normal, Certainty: wild-guess
N:    
N:    Check: binaries, Type: binary, udeb
N: 
I: srain: spelling-error-in-binary usr/bin/srain Closeing Closing
N: 
N:    Lintian found a spelling error in the given binary. Lintian has a list
N:    of common misspellings that it looks for. It does not have a dictionary
N:    like a spelling checker does.
N:    
N:    If the string containing the spelling error is translated with the help
N:    of gettext or a similar tool, please fix the error in the translations
N:    as well as the English text to avoid making the translations fuzzy. With
N:    gettext, for example, this means you should also fix the spelling
N:    mistake in the corresponding msgids in the *.po files.
N:    
N:    You can often find the word in the source code by running:
N:    
N:     grep -rw <word> <source-tree>
N:    
N:    This tag may produce false positives for words that contain non-ASCII
N:    characters due to limitations in strings.
N:    
N:    Severity: minor, Certainty: wild-guess
N:    
N:    Check: binaries, Type: binary, udeb
N: 
I: srain: spelling-error-in-binary usr/bin/srain Unspported Unsupported
I: srain: spelling-error-in-binary usr/bin/srain channnel channel
I: srain: spelling-error-in-binary usr/bin/srain channnels channels
I: srain: spelling-error-in-binary usr/bin/srain opiton option
I: srain: spelling-error-in-binary usr/bin/srain recieved received
I: srain: spelling-error-in-binary usr/bin/srain vaule value
I: srain source: testsuite-autopkgtest-missing
N: 
N:    This package does not declare a test suite.
N:    
N:    Having a test suite aids with automated quality assurance of the archive
N:    outside of your package. For example, if your package has a test suite
N:    it is possible to re-run that test suite when any of your package's
N:    dependencies have a new version and check whether that update causes
N:    problems for your package.
N:    
N:    In addition, since May 2018 these tests now influence migration from
N:    unstable to testing:
N:    
N:     https://lists.debian.org/debian-devel-announce/2018/05/msg00001.html
N:    
N:    Please add a debian/tests/control file to your package to declare a
N:    testsuite, but please make sure to only add autopkgtests if they provide
N:    meaningful coverage of your package.
N:    
N:    Refer to https://ci.debian.net/doc/ for details.
N:    
N:    Severity: wishlist, Certainty: certain
N:    
N:    Check: testsuite, Type: source
N: 
X: srain source: debian-watch-does-not-check-gpg-signature
N: 
N:    This watch file does not specify a means to verify the upstream tarball
N:    using a cryptographic signature.
N:    
N:    If upstream distributions provides such signatures, please use the
N:    pgpsigurlmangle options in this watch file's opts= to generate the URL
N:    of an upstream GPG signature. This signature is automatically downloaded
N:    and verified against a keyring stored in debian/upstream/signing-key.asc
N:    
N:    Of course, not all upstreams provide such signatures but you could
N:    request them as a way of verifying that no third party has modified the
N:    code after its release (projects such as phpmyadmin, unrealircd, and
N:    proftpd have suffered from this kind of attack).
N:    
N:    Refer to the uscan(1) manual page for details.
N:    
N:    Severity: pedantic, Certainty: certain
N:    
N:    Check: debian/watch, Type: source
N:    
N:    This tag is marked experimental, which means that the code that
N:    generates it is not as well-tested as the rest of Lintian and might
N:    still give surprising results. Feel free to ignore experimental tags
N:    that do not seem to make sense, though of course bug reports are always
N:    welcome.
N: 
```

Signed-off-by: David Heidelberg <david@ixit.cz>