### PR TITLE
debian: bump to 1.0.2, fix copyright, fix another warnings

### DIFF
--- a/pack/debian/changelog
+++ b/pack/debian/changelog
@@ -1,8 +1,8 @@
-srain (1.0.1-1) unstable; urgency=medium
+srain (1.0.2-1) unstable; urgency=medium
 
-  * cleaned debian stuff
+  * [David Heidelberg] version bump & stuff
 
- -- David Heidelberg <david@ixit.cz>  Mon, 16 Mar 2020 13:25:39 +0000
+ -- Shengyu Zhang <i@silverrainz.me>  Sun, 19 Apr 2020 13:25:39 +0000
 
 srain (1.0.0-1) unstable; urgency=medium
 

--- a/pack/debian/copyright
+++ b/pack/debian/copyright
@@ -6,6 +6,10 @@ Files: *
 Copyright: 2016 Shengyu Zhang <i@silverrainz.me>
 License: GPL-3.0+
 
+Files: data/srain.metainfo.xml
+Copyright: 2016 Shengyu Zhang <i@silverrainz.me>
+License: FSFAP
+
 Files: debian/*
 Copyright: 2016 yangfl <mmyangfl@gmail.com>
 License: Expat
@@ -26,6 +30,11 @@ License: GPL-3.0+
  .
  On Debian systems, the complete text of the GNU General
  Public License version 3 can be found in "/usr/share/common-licenses/GPL-3".
+
+License: FSFAP
+ Copying and distribution of this file, with or without modification, are
+ permitted in any medium without royalty provided the copyright notice and
+ this notice are preserved. This file is offered as-is, without any warranty.
 
 License: Expat
  Copyright (c) 1998, 1999, 2000 Thai Open Source Software Center Ltd

--- a/pack/debian/menu
+++ b/pack/debian/menu
@@ -1,2 +1,0 @@
-?package(srain):needs="X11|text|vc|wm" section="Applications/Network"\
-  title="Srain" command="/usr/bin/srain"


### PR DESCRIPTION
Depends on: https://github.com/SrainApp/srain/pull/240
Copyright warning will disappear with 1.0.3, metainfo licence hasn't
been included in debian/copyright file.

Also fixing non-maintainer build warning, by using author name in
changelog file.

Signed-off-by: David Heidelberg <david@ixit.cz>